### PR TITLE
[#6] support platform dark mode

### DIFF
--- a/src/app/ThemeToggler.svelte
+++ b/src/app/ThemeToggler.svelte
@@ -2,11 +2,13 @@
   import FaRegSun from 'svelte-icons/fa/FaRegSun.svelte'
   import FaRegMoon from 'svelte-icons/fa/FaRegMoon.svelte'
   import { onMount } from 'svelte'
+  import { shouldUseDarkModeColorScheme } from './utils'
+
   let isDarkTheme = false
   onMount(async () => {
-    const cachedValue = window.localStorage.getItem('isDarkTheme') === 'true'
-    if (cachedValue) {
-      toggleTheme()
+    if (shouldUseDarkModeColorScheme()) {
+      isDarkTheme = !isDarkTheme
+      window.document.body.classList.toggle('dark')
     }
     setTimeout(() => {
       window.document.body.classList.toggle('color-transition')

--- a/src/app/ThemeToggler.svelte
+++ b/src/app/ThemeToggler.svelte
@@ -1,10 +1,15 @@
 <script>
   import FaRegSun from 'svelte-icons/fa/FaRegSun.svelte'
   import FaRegMoon from 'svelte-icons/fa/FaRegMoon.svelte'
-  import { onMount } from 'svelte'
-  import { shouldUseDarkModeColorScheme } from './utils'
+  import { onMount, onDestroy } from 'svelte'
+  import {
+    addColorSchemeEventListener,
+    shouldUseDarkModeColorScheme,
+  } from './utils'
 
   let isDarkTheme = false
+  let colorSchemeSubscriber = null
+
   onMount(async () => {
     if (shouldUseDarkModeColorScheme()) {
       changeColorScheme(!isDarkTheme)
@@ -12,6 +17,14 @@
     setTimeout(() => {
       window.document.body.classList.toggle('color-transition')
     }, 500)
+
+    colorSchemeSubscriber = addColorSchemeEventListener(changeColorScheme)
+  })
+
+  onDestroy(() => {
+    if (colorSchemeSubscriber != null) {
+      colorSchemeSubscriber.remove()
+    }
   })
 
   function toggleTheme() {

--- a/src/app/ThemeToggler.svelte
+++ b/src/app/ThemeToggler.svelte
@@ -7,8 +7,7 @@
   let isDarkTheme = false
   onMount(async () => {
     if (shouldUseDarkModeColorScheme()) {
-      isDarkTheme = !isDarkTheme
-      window.document.body.classList.toggle('dark')
+      changeColorScheme(!isDarkTheme)
     }
     setTimeout(() => {
       window.document.body.classList.toggle('color-transition')
@@ -16,8 +15,12 @@
   })
 
   function toggleTheme() {
-    isDarkTheme = !isDarkTheme
-    window.localStorage.setItem('isDarkTheme', isDarkTheme)
+    window.localStorage.setItem('isDarkTheme', !isDarkTheme)
+    changeColorScheme(!isDarkTheme)
+  }
+
+  function changeColorScheme(value) {
+    isDarkTheme = value
     window.document.body.classList.toggle('dark')
   }
 </script>

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -19,6 +19,10 @@ export function handleLogout() {
   location.href = `https://akun-kp.cs.ui.ac.id/cas/logout?service=${DOMAIN}`
 }
 
+export function hasCachedColorScheme() {
+  return window.localStorage.getItem('isDarkTheme') != null
+}
+
 /**
  * Check if user uses dark mode color scheme
  */
@@ -34,4 +38,31 @@ export function shouldUseDarkModeColorScheme() {
   }
 
   return window.matchMedia('(prefers-color-scheme: dark)').matches
+}
+
+/**
+ * Listen to prefered color scheme event and pass dark mode flag to callback.
+ * Returns subscriber object.
+ * @param {function} listener will receive dark mode flag
+ */
+export function addColorSchemeEventListener(callback) {
+  if (hasCachedColorScheme()) {
+    return {
+      remove: () => {},
+    }
+  }
+
+  const media = window.matchMedia('(prefers-color-scheme: dark)')
+  const callbackWrapper = (event) => {
+    if (hasCachedColorScheme()) return
+    const isDarkMode = event.matches
+    callback(isDarkMode)
+  }
+
+  media.addEventListener('change', callbackWrapper, false)
+  return {
+    remove: () => {
+      media.removeEventListener('change', callbackWrapper, false)
+    },
+  }
 }

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -18,3 +18,20 @@ export function handleLogout() {
   localStorage.removeItem('token')
   location.href = `https://akun-kp.cs.ui.ac.id/cas/logout?service=${DOMAIN}`
 }
+
+/**
+ * Check if user uses dark mode color scheme
+ */
+export function shouldUseDarkModeColorScheme() {
+  const cachedValue = window.localStorage.getItem('isDarkTheme')
+
+  // has cached value or not supported -> check if dark mode
+  if (
+    cachedValue != null ||
+    window.matchMedia('(prefers-color-scheme)').media === 'not all'
+  ) {
+    return cachedValue == 'true'
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+}


### PR DESCRIPTION
As we're already using JS way to have dark mode, we will continue to use it. So to support color scheme media CSS, we will query via JS and if the query result matches with dark value then we will automatically apply dark mode [doc]

**Test plan (required)**

N/A

**Code formatting**

N/A

**Closing issues**

Closes #6 
