### PR TITLE
Update api.js

### DIFF
--- a/src/app/api.js
+++ b/src/app/api.js
@@ -3,5 +3,5 @@ import { post } from './http'
 const DOMAIN = window.location.origin
 
 export function postAuthTicket(ticket) {
-  return post('auth/', { ticket, service_url: DOMAIN })
+  return post('auth/', { ticket, service: DOMAIN })
 }


### PR DESCRIPTION
With the latest changes made to the cloud_functions repo, `service` is now required to be passed through the Auth API to enable multisite debugging (localhost, etc). We pass this when calling the API but previously it's `service_url`, not `service` and causing the web auth function to regress.
